### PR TITLE
Add watchlist Show-all mode + client-side sort + bulk draft delete

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -2,6 +2,8 @@ import { initTokenAndAccountUtil } from './utils/tokenAndAccountUtil.js';
 import { initFactsheet } from './utils/factsheet.js';
 import { initPortfolio } from './portfolio.js';
 import { initHoldingsTableModule } from './utils/holdingsTable.js';
+import { initWatchlistSortModule } from './utils/watchlistSort.js';
+import { initDraftsBulkDeleteModule } from './utils/draftsBulkDelete.js';
 
 export function main() {
   // Listen for messages from the MAIN world
@@ -99,7 +101,9 @@ export function main() {
   initFactsheet();
   initPortfolio();
   initHoldingsTableModule();
-  
+  initWatchlistSortModule();
+  initDraftsBulkDeleteModule();
+
   // Signal that init is ready
   window.postMessage({ type: 'INIT_READY' }, '*');
 }

--- a/src/utils/draftsBulkDelete.js
+++ b/src/utils/draftsBulkDelete.js
@@ -1,0 +1,455 @@
+// Bulk-delete for the Drafts page.
+// - Adds a checkbox to each row + a master checkbox in the header
+// - Adds a toolbar above the table with:
+//     "Select all 'Copy of…' drafts" button — selects rows whose name starts
+//     with "Copy of" (case-insensitive, ignores rows starting with "SAVE")
+//     "Delete selected (N)" button — clicks each row's trash → confirms delete
+//       sequentially with short delays
+
+import { log } from "./logger.js";
+
+let pollInterval = null;
+let observer = null;
+let currentTable = null;
+let deleteInProgress = false;
+
+// The exact SVG path Composer uses for the trash icon (from user-supplied HTML)
+const TRASH_PATH_SIG = "M216,48H176";
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+function getDraftsTable() {
+  const tables = document.querySelectorAll("table");
+  for (const table of tables) {
+    const thead = table.querySelector("thead");
+    if (!thead) continue;
+    const headerText = (thead.textContent || "").toLowerCase();
+    const hasTrashButton = !!findAnyTrashButton(table);
+    if (
+      headerText.includes("name") &&
+      headerText.includes("created") &&
+      headerText.includes("last modified") &&
+      hasTrashButton
+    ) {
+      return table;
+    }
+  }
+  return null;
+}
+
+function findAnyTrashButton(root) {
+  const svgs = root.querySelectorAll("svg path");
+  for (const path of svgs) {
+    const d = path.getAttribute("d") || "";
+    if (d.startsWith(TRASH_PATH_SIG)) {
+      return path.closest("button");
+    }
+  }
+  return null;
+}
+
+function findTrashButton(row) {
+  const svgs = row.querySelectorAll("svg path");
+  for (const path of svgs) {
+    const d = path.getAttribute("d") || "";
+    if (d.startsWith(TRASH_PATH_SIG)) {
+      return path.closest("button");
+    }
+  }
+  return null;
+}
+
+function getRowName(row) {
+  // Name lives in the first non-checkbox cell. It's typically "Copy of X"
+  // followed by a "Trading: TKR1, TKR2, …" subtext line with no newline
+  // separator, so we split off the ticker subtext explicitly.
+  const cells = row.querySelectorAll(":scope > td");
+  for (const cell of cells) {
+    if (cell.classList.contains("cqt-checkbox-col")) continue;
+    const txt = (cell.textContent || "").trim();
+    if (!txt) continue;
+    // Skip cells that are just button labels or dates
+    if (/^(Buy|Watch)$/i.test(txt)) continue;
+    if (/^[A-Z][a-z]{2}\s+\d{1,2},?\s+\d{4}$/.test(txt)) continue;
+    // Strip the "Trading: …" ticker list that lives in the same cell
+    const beforeTrading = txt.split(/\s*Trading:/i)[0].trim();
+    return beforeTrading || txt.split("\n")[0].trim();
+  }
+  return "";
+}
+
+// Extract the symphony ID from any /symphony/{id} link inside the row.
+// Used as a stable identity for matching rows across React re-renders.
+function getRowSymphonyId(row) {
+  const link = row.querySelector("a[href*='/symphony/']");
+  if (!link) return null;
+  const m = (link.getAttribute("href") || link.href || "").match(/\/symphony\/([^/?#]+)/);
+  return m ? m[1] : null;
+}
+
+function findRowBySymphonyId(table, id) {
+  if (!id) return null;
+  const tbody = table.querySelector("tbody");
+  if (!tbody) return null;
+  for (const row of tbody.querySelectorAll(":scope > tr")) {
+    if (getRowSymphonyId(row) === id) return row;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Checkbox injection
+// ---------------------------------------------------------------------------
+
+function ensureCheckboxColumn(table) {
+  const thead = table.querySelector("thead tr");
+  const tbody = table.querySelector("tbody");
+  if (!thead || !tbody) return;
+
+  // Header cell
+  if (!thead.querySelector("th.cqt-checkbox-col")) {
+    const th = document.createElement("th");
+    th.className = "cqt-checkbox-col";
+    th.style.cssText = "width:32px;padding:0 4px;";
+    const master = document.createElement("input");
+    master.type = "checkbox";
+    master.className = "cqt-master-checkbox";
+    master.title = "Select all";
+    master.style.cssText = "cursor:pointer;";
+    master.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const checked = master.checked;
+      tbody
+        .querySelectorAll("input.cqt-row-checkbox")
+        .forEach((cb) => (cb.checked = checked));
+      updateDeleteButtonLabel();
+    });
+    th.appendChild(master);
+    thead.insertBefore(th, thead.firstChild);
+  }
+
+  // Row cells
+  const rows = tbody.querySelectorAll("tr");
+  rows.forEach((row) => {
+    if (row.querySelector("td.cqt-checkbox-col")) return;
+    // Skip rows that don't have a trash button (not a real draft row)
+    if (!findTrashButton(row)) return;
+
+    const td = document.createElement("td");
+    td.className = "cqt-checkbox-col";
+    td.style.cssText = "width:32px;padding:0 4px;text-align:center;";
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.className = "cqt-row-checkbox";
+    cb.style.cssText = "cursor:pointer;";
+    cb.addEventListener("click", (e) => {
+      e.stopPropagation();
+      updateDeleteButtonLabel();
+    });
+    td.appendChild(cb);
+    row.insertBefore(td, row.firstChild);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar
+// ---------------------------------------------------------------------------
+
+function ensureToolbar(table) {
+  let toolbar = document.getElementById("cqt-drafts-toolbar");
+  if (toolbar) return toolbar;
+
+  toolbar = document.createElement("div");
+  toolbar.id = "cqt-drafts-toolbar";
+  toolbar.style.cssText =
+    "display:flex;gap:8px;align-items:center;padding:8px 12px;margin:8px 0;background:#F9FAFB;border:1px solid #E5E7EB;border-radius:6px;font-size:13px;";
+
+  const selectCopyBtn = document.createElement("button");
+  selectCopyBtn.type = "button";
+  selectCopyBtn.textContent = 'Select all "Copy of…" drafts';
+  selectCopyBtn.style.cssText =
+    "padding:6px 12px;border:1px solid #D1D5DB;background:white;border-radius:4px;cursor:pointer;";
+  selectCopyBtn.addEventListener("click", () => {
+    const t = getDraftsTable();
+    if (t) selectCopyOfDrafts(t);
+  });
+
+  const clearBtn = document.createElement("button");
+  clearBtn.type = "button";
+  clearBtn.textContent = "Clear";
+  clearBtn.style.cssText =
+    "padding:6px 12px;border:1px solid #D1D5DB;background:white;border-radius:4px;cursor:pointer;";
+  clearBtn.addEventListener("click", () => {
+    const t = getDraftsTable();
+    if (!t) return;
+    t.querySelectorAll("input.cqt-row-checkbox, input.cqt-master-checkbox").forEach(
+      (cb) => (cb.checked = false)
+    );
+    updateDeleteButtonLabel();
+  });
+
+  const deleteBtn = document.createElement("button");
+  deleteBtn.type = "button";
+  deleteBtn.id = "cqt-delete-selected-btn";
+  deleteBtn.textContent = "Delete selected (0)";
+  deleteBtn.disabled = true;
+  deleteBtn.style.cssText =
+    "padding:6px 12px;border:1px solid #DC2626;background:#EF4444;color:white;border-radius:4px;cursor:pointer;margin-left:auto;";
+  deleteBtn.addEventListener("click", () => {
+    const t = getDraftsTable();
+    if (t) runBulkDelete(t);
+  });
+
+  const status = document.createElement("span");
+  status.id = "cqt-bulk-status";
+  status.style.cssText = "color:#6B7280;margin-left:8px;";
+
+  toolbar.appendChild(selectCopyBtn);
+  toolbar.appendChild(clearBtn);
+  toolbar.appendChild(status);
+  toolbar.appendChild(deleteBtn);
+
+  table.parentElement?.insertBefore(toolbar, table);
+  return toolbar;
+}
+
+function getSelectedRows(table) {
+  const tbody = table.querySelector("tbody");
+  if (!tbody) return [];
+  const rows = [];
+  tbody.querySelectorAll("tr").forEach((row) => {
+    const cb = row.querySelector("input.cqt-row-checkbox");
+    if (cb?.checked) rows.push(row);
+  });
+  return rows;
+}
+
+function updateDeleteButtonLabel() {
+  const btn = document.getElementById("cqt-delete-selected-btn");
+  if (!btn || !currentTable) return;
+  const count = getSelectedRows(currentTable).length;
+  btn.textContent = `Delete selected (${count})`;
+  btn.disabled = count === 0 || deleteInProgress;
+  btn.style.opacity = btn.disabled ? "0.5" : "1";
+}
+
+function setStatus(text) {
+  const s = document.getElementById("cqt-bulk-status");
+  if (s) s.textContent = text || "";
+}
+
+// ---------------------------------------------------------------------------
+// "Copy of…" auto-selection
+// ---------------------------------------------------------------------------
+
+function selectCopyOfDrafts(table) {
+  // Make sure checkboxes are present on current rows before selecting
+  ensureCheckboxColumn(table);
+
+  const tbody = table.querySelector("tbody");
+  if (!tbody) return;
+  let matched = 0;
+  let scanned = 0;
+  const samples = [];
+  tbody.querySelectorAll(":scope > tr").forEach((row) => {
+    const cb = row.querySelector("input.cqt-row-checkbox");
+    if (!cb) return;
+    scanned++;
+    const name = getRowName(row);
+    if (samples.length < 3) samples.push(name);
+    if (!name) return;
+    const lower = name.toLowerCase();
+    if (lower.startsWith("save")) return;
+    if (lower.startsWith("copy of")) {
+      cb.checked = true;
+      matched++;
+    }
+  });
+  log(
+    `[draftsBulkDelete] select-copy: scanned=${scanned} matched=${matched} sample-names=${JSON.stringify(samples)}`
+  );
+  updateDeleteButtonLabel();
+  setStatus(
+    matched > 0
+      ? `Selected ${matched} "Copy of…" drafts`
+      : `No "Copy of…" drafts found (scanned ${scanned} rows — check console for samples)`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bulk delete execution
+// ---------------------------------------------------------------------------
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitFor(predicate, timeoutMs = 2000, intervalMs = 50) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = predicate();
+    if (result) return result;
+    await sleep(intervalMs);
+  }
+  return null;
+}
+
+function findYesDeleteButton() {
+  // Find a visible button with text "Yes, delete"
+  const buttons = document.querySelectorAll("button");
+  for (const btn of buttons) {
+    const txt = (btn.textContent || "").trim().toLowerCase();
+    if (txt === "yes, delete") return btn;
+  }
+  return null;
+}
+
+// Find and dismiss Composer's "Something went wrong" error popup.
+function dismissErrorPopup() {
+  const buttons = document.querySelectorAll("button");
+  for (const btn of buttons) {
+    const t = (btn.textContent || "").trim().toLowerCase();
+    if (t === "no, don't delete" || t === "cancel" || t === "close") {
+      btn.click();
+      return true;
+    }
+  }
+  return false;
+}
+
+async function deleteOneBySymphonyId(table, entry) {
+  const { id, name } = entry;
+  // Re-locate the row each iteration — DOM nodes can be reused by React.
+  const row = findRowBySymphonyId(table, id);
+  if (!row) return { ok: false, reason: "row-not-found" };
+
+  const trashBtn = findTrashButton(row);
+  if (!trashBtn) return { ok: false, reason: "no-trash" };
+  trashBtn.click();
+
+  const yesBtn = await waitFor(findYesDeleteButton, 2500);
+  if (!yesBtn) return { ok: false, reason: "no-confirm" };
+  yesBtn.click();
+
+  // Success signal: the row with this symphony ID is no longer in the DOM.
+  // We poll directly for that — ignoring dialog close timing, which can
+  // happen before React finishes removing the row.
+  const rowGone = await waitFor(
+    () => findRowBySymphonyId(table, id) === null,
+    6000
+  );
+
+  if (!rowGone) {
+    // Likely hit Composer's "Something went wrong" popup. Dismiss and bail.
+    dismissErrorPopup();
+    await sleep(300);
+    return { ok: false, reason: "row-persisted" };
+  }
+
+  // Brief settle so React fully reconciles before the next click.
+  await sleep(250);
+  return { ok: true, reason: "ok" };
+}
+
+function clearAllCheckboxes(table) {
+  table
+    .querySelectorAll("input.cqt-row-checkbox, input.cqt-master-checkbox")
+    .forEach((cb) => (cb.checked = false));
+}
+
+async function runBulkDelete(table) {
+  if (deleteInProgress) return;
+  const selected = getSelectedRows(table);
+  if (!selected.length) return;
+
+  // Snapshot stable identity (symphony ID) for each selected row NOW, before
+  // anything mutates the DOM. We'll look rows up by ID each iteration so
+  // we're immune to React reusing <tr> elements or shuffling content.
+  const entries = selected
+    .map((r) => ({ id: getRowSymphonyId(r), name: getRowName(r) }))
+    .filter((e) => !!e.id);
+
+  const dropped = selected.length - entries.length;
+  if (dropped > 0) {
+    log(
+      `[draftsBulkDelete] ${dropped} selected row(s) had no symphony ID and were skipped`
+    );
+  }
+  if (!entries.length) {
+    setStatus("Could not identify selected drafts (no symphony IDs found).");
+    return;
+  }
+
+  const confirmed = window.confirm(
+    `Delete ${entries.length} draft${entries.length === 1 ? "" : "s"}? This cannot be undone.`
+  );
+  if (!confirmed) return;
+
+  clearAllCheckboxes(table);
+  updateDeleteButtonLabel();
+
+  deleteInProgress = true;
+  let done = 0;
+  let failed = 0;
+  for (const entry of entries) {
+    done++;
+    setStatus(
+      `Deleting ${done} of ${entries.length}: ${entry.name.slice(0, 60)}`
+    );
+    const result = await deleteOneBySymphonyId(table, entry);
+    if (!result.ok) {
+      failed++;
+      log(
+        `[draftsBulkDelete] failed: id=${entry.id} "${entry.name}"  reason=${result.reason}`
+      );
+    }
+  }
+
+  deleteInProgress = false;
+  setStatus(
+    failed
+      ? `Deleted ${done - failed} of ${entries.length} (${failed} failed — see console)`
+      : `Deleted ${done} draft${done === 1 ? "" : "s"} ✔`
+  );
+  clearAllCheckboxes(table);
+  updateDeleteButtonLabel();
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+function tick() {
+  const table = getDraftsTable();
+  if (!table) return;
+
+  currentTable = table;
+  ensureToolbar(table);
+  ensureCheckboxColumn(table);
+  updateDeleteButtonLabel();
+
+  if (!observer) {
+    // Re-inject checkboxes after React re-renders rows (e.g. after deletes)
+    observer = new MutationObserver(() => {
+      if (deleteInProgress) return;
+      ensureCheckboxColumn(table);
+      updateDeleteButtonLabel();
+    });
+    observer.observe(table.querySelector("tbody") || table, {
+      childList: true,
+      subtree: false,
+    });
+  }
+}
+
+export function initDraftsBulkDeleteModule() {
+  log("[draftsBulkDelete] module init");
+  if (pollInterval) clearInterval(pollInterval);
+  pollInterval = setInterval(tick, 1000);
+  window.addEventListener("unload", () => {
+    if (pollInterval) clearInterval(pollInterval);
+    if (observer) observer.disconnect();
+  });
+}

--- a/src/utils/watchlistSort.js
+++ b/src/utils/watchlistSort.js
@@ -51,7 +51,12 @@ const COLUMN_VALUE_GETTERS = {
   name: (s) => (s.name || "").toLowerCase(),
   todayschange: (s) => (typeof s._todaysChange === "number" ? s._todaysChange : null),
   watchedsince: (s) => (s.watched_since ? new Date(s.watched_since).getTime() : null),
-  outofsampledate: () => null, // not in watchlist API
+  outofsampledate: (s) => {
+    const raw = s.last_semantic_update_at;
+    if (!raw) return null;
+    const t = new Date(raw.split("[")[0]).getTime();
+    return isNaN(t) ? null : t;
+  },
   annualizedreturn: (s) => s.annualized_rate_of_return ?? null,
   cumulativereturn: (s) => s.simple_return ?? null,
   sharperatio: (s) => s.sharpe_ratio ?? null,
@@ -545,7 +550,9 @@ function renderRow(symphony, colMap, templateRow) {
   const { text: tcText, color: tcColor } = fmtTodaysChange(symphony._todaysChange);
   setCellTextPreserveStyle(cells[colMap.todayschange], tcText, tcColor);
   setCellTextPreserveStyle(cells[colMap.watchedsince], fmtDate(symphony.watched_since));
-  setCellTextPreserveStyle(cells[colMap.outofsampledate], "—");
+  const oosRaw = symphony.last_semantic_update_at;
+  const oosIso = oosRaw ? oosRaw.split("[")[0] : null;
+  setCellTextPreserveStyle(cells[colMap.outofsampledate], fmtDate(oosIso));
   setCellTextPreserveStyle(
     cells[colMap.annualizedreturn],
     fmtPercent((symphony.annualized_rate_of_return ?? 0) * 100, 1)

--- a/src/utils/watchlistSort.js
+++ b/src/utils/watchlistSort.js
@@ -1,0 +1,814 @@
+// Adds sort functionality and a "Show all" mode to the watchlist page.
+//
+// Problem Composer's watchlist has:
+//   - Pagination is server-side (20 rows per page), so clicking a sort arrow
+//     only sorts the visible page.
+//   - "Today's Change" has no sort arrow at all.
+//
+// What this module adds:
+//   - A small "Show all" toggle button inside the Today's Change header cell.
+//     Click it once → fetch the full watchlist + current quotes, render every
+//     symphony in one scrolling tbody, hide Composer's pagination. Click
+//     again → revert to Composer's paginated view.
+//   - A sort arrow on Today's Change (which Composer doesn't render).
+//   - While "Show all" is active, clicks on ANY column header sort our rows
+//     client-side using the raw API values. Click the same header again to
+//     toggle asc/desc.
+//
+// Uses only endpoints Composer already calls (backtest-api/v1/watchlist,
+// stagehand-api/v1/public/quotes) and the extension's existing
+// getTokenAndAccount helper. No new permissions needed.
+
+import { log } from "./logger.js";
+import { getTokenAndAccount, buildHeaders } from "./tokenAndAccountUtil.js";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let showAllActive = false;
+let watchlistCache = null;
+let watchlistCacheTime = 0;
+let currentSortKey = null; // normalized column key, e.g. "todayschange"
+let currentSortDir = "desc"; // 'asc' | 'desc'
+let sortedSymphonies = [];
+let originalTbody = null;
+let customTbody = null;
+let stashedPagination = [];
+let observer = null;
+let pollInterval = null;
+let isApplyingDomChange = false;
+
+const WATCHLIST_CACHE_TTL = 5 * 60 * 1000;
+const TODAYS_CHANGE_RE = /today.{0,3}s\s+change/i;
+const WATCHED_SINCE_RE = /watched\s+since/i;
+
+// ---------------------------------------------------------------------------
+// Column mapping. Keys are derived from header text via headerKey().
+// ---------------------------------------------------------------------------
+
+const COLUMN_VALUE_GETTERS = {
+  name: (s) => (s.name || "").toLowerCase(),
+  todayschange: (s) => (typeof s._todaysChange === "number" ? s._todaysChange : null),
+  watchedsince: (s) => (s.watched_since ? new Date(s.watched_since).getTime() : null),
+  outofsampledate: () => null, // not in watchlist API
+  annualizedreturn: (s) => s.annualized_rate_of_return ?? null,
+  cumulativereturn: (s) => s.simple_return ?? null,
+  sharperatio: (s) => s.sharpe_ratio ?? null,
+  calmarratio: (s) => s.calmar_ratio ?? null,
+  standarddeviation: (s) => s.standard_deviation ?? null,
+  maxdrawdown: (s) => s.max_drawdown ?? null,
+  trailing1mreturn: (s) => s.trailing_one_month_return ?? null,
+  trailing3mreturn: (s) => s.trailing_three_month_return ?? null,
+};
+
+function headerKey(text) {
+  return (text || "").trim().toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+function getWatchlistTable() {
+  const tables = document.querySelectorAll("table");
+  for (const table of tables) {
+    const thead = table.querySelector("thead");
+    if (!thead) continue;
+    const text = thead.textContent || "";
+    if (TODAYS_CHANGE_RE.test(text) && WATCHED_SINCE_RE.test(text)) {
+      return table;
+    }
+  }
+  return null;
+}
+
+function findTodaysChangeHeader(table) {
+  const headers = table.querySelectorAll("thead th");
+  for (const th of headers) {
+    if (TODAYS_CHANGE_RE.test(th.textContent || "")) return th;
+  }
+  return null;
+}
+
+function buildColumnIndexMap(table) {
+  const headers = Array.from(table.querySelectorAll("thead th"));
+  const map = {};
+  headers.forEach((th, i) => {
+    const key = headerKey(th.textContent);
+    if (key && COLUMN_VALUE_GETTERS[key]) {
+      map[key] = i;
+    }
+  });
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async function fetchWatchlist() {
+  const now = Date.now();
+  if (watchlistCache && now - watchlistCacheTime < WATCHLIST_CACHE_TTL) {
+    return watchlistCache;
+  }
+  const { token, sessionId } = await getTokenAndAccount();
+  const resp = await fetch(
+    "https://backtest-api.composer.trade/api/v1/watchlist",
+    { headers: buildHeaders(token, sessionId) }
+  );
+  if (!resp.ok) throw new Error(`watchlist HTTP ${resp.status}`);
+  const data = await resp.json();
+  watchlistCache = data;
+  watchlistCacheTime = now;
+  return data;
+}
+
+async function fetchQuotesChunk(tickers, token, sessionId) {
+  const resp = await fetch(
+    "https://stagehand-api.composer.trade/api/v1/public/quotes",
+    {
+      method: "POST",
+      headers: {
+        ...buildHeaders(token, sessionId),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ tickers }),
+    }
+  );
+  if (!resp.ok) throw new Error(`quotes HTTP ${resp.status}`);
+  return resp.json();
+}
+
+async function fetchQuotes(tickers) {
+  if (!tickers.length) return {};
+  const { token, sessionId } = await getTokenAndAccount();
+  // Batch to avoid large POST bodies / server-side limits
+  const BATCH_SIZE = 100;
+  const merged = {};
+  for (let i = 0; i < tickers.length; i += BATCH_SIZE) {
+    const chunk = tickers.slice(i, i + BATCH_SIZE);
+    const res = await fetchQuotesChunk(chunk, token, sessionId);
+    Object.assign(merged, res);
+  }
+  return merged;
+}
+
+function collectTickers(symphonies) {
+  const set = new Set();
+  for (const s of symphonies) {
+    const h = s.last_backtest_holdings || {};
+    for (const t of Object.keys(h)) {
+      if (!t || t === "$USD" || t === "USD") continue;
+      set.add(`EQUITIES::${t}//USD`);
+    }
+  }
+  return [...set];
+}
+
+function computeTodaysChange(symphony, quotes) {
+  const holdings = symphony.last_backtest_holdings || {};
+  let totalValue = 0;
+  let weightedChangeDollar = 0;
+  let anyMatched = false;
+  for (const [ticker, value] of Object.entries(holdings)) {
+    if (!value || value <= 0) continue;
+    if (ticker === "$USD" || ticker === "USD") {
+      totalValue += value;
+      anyMatched = true;
+      continue;
+    }
+    const qKey = `EQUITIES::${ticker}//USD`;
+    const q = quotes[qKey];
+    if (!q || !q.price || !q.previous_price) continue;
+    const change = (q.price - q.previous_price) / q.previous_price;
+    weightedChangeDollar += value * change;
+    totalValue += value;
+    anyMatched = true;
+  }
+  if (!anyMatched || totalValue === 0) return null;
+  return (weightedChangeDollar / totalValue) * 100;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function fmtPercent(val, decimals = 1) {
+  if (val === null || val === undefined || isNaN(val)) return "—";
+  return `${val.toFixed(decimals)}%`;
+}
+function fmtRatio(val, decimals = 2) {
+  if (val === null || val === undefined || isNaN(val)) return "—";
+  return val.toFixed(decimals);
+}
+function fmtDate(iso) {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch (_) {
+    return "—";
+  }
+}
+function fmtTodaysChange(pct) {
+  if (pct === null || pct === undefined || isNaN(pct))
+    return { text: "—", color: "" };
+  const arrow = pct >= 0 ? "↑" : "↓";
+  const color = pct >= 0 ? "#16a34a" : "#dc2626";
+  return { text: `${arrow} ${Math.abs(pct).toFixed(2)}%`, color };
+}
+
+// ---------------------------------------------------------------------------
+// Visual: sort arrow + Show-all toggle button
+// ---------------------------------------------------------------------------
+
+function buildSortArrows() {
+  const wrap = document.createElement("span");
+  wrap.className = "cqt-watchlist-sort-arrows";
+  wrap.style.cssText =
+    "display:inline-flex;flex-direction:column;align-items:center;justify-content:center;gap:1px;margin-left:4px;vertical-align:middle;";
+  wrap.innerHTML = `
+    <span class="cqt-arrow-up" style="display:block;width:0;height:0;border-left:3px solid transparent;border-right:3px solid transparent;border-bottom:4px solid rgba(0,0,0,0.25);"></span>
+    <span class="cqt-arrow-down" style="display:block;width:0;height:0;border-left:3px solid transparent;border-right:3px solid transparent;border-top:4px solid rgba(0,0,0,0.25);"></span>
+  `;
+  return wrap;
+}
+
+function updateArrowForKey(th, key) {
+  const up = th.querySelector(".cqt-arrow-up");
+  const down = th.querySelector(".cqt-arrow-down");
+  if (!up || !down) return;
+  const active = currentSortKey === key;
+  up.style.borderBottomColor =
+    active && currentSortDir === "asc" ? "rgba(0,0,0,0.85)" : "rgba(0,0,0,0.25)";
+  down.style.borderTopColor =
+    active && currentSortDir === "desc" ? "rgba(0,0,0,0.85)" : "rgba(0,0,0,0.25)";
+}
+
+function ensureTodaysChangeArrow(table) {
+  const th = findTodaysChangeHeader(table);
+  if (!th) return;
+  if (!th.querySelector(".cqt-watchlist-sort-arrows")) {
+    th.appendChild(buildSortArrows());
+  }
+  // Tooltip hint so users know clicking will trigger Show all
+  const hint = showAllActive
+    ? "Click to sort by Today's Change"
+    : "Click to load all symphonies and sort by Today's Change (may take a moment)";
+  th.title = hint;
+  th.style.cursor = "pointer";
+  updateArrowForKey(th, "todayschange");
+}
+
+function updateActiveArrowOnNativeHeaders(table) {
+  // We don't inject arrows into native columns (Composer already has them),
+  // but we do mark our own arrow state on Today's Change.
+  ensureTodaysChangeArrow(table);
+}
+
+function findDisplayDropdown() {
+  // Composer's "Display" column chooser sits in the top-right of the watchlist
+  // controls. Match by its exact button text.
+  const candidates = document.querySelectorAll("button, [role='button']");
+  for (const el of candidates) {
+    const txt = (el.textContent || "").trim();
+    // "Display" possibly followed by dropdown chevron
+    if (/^Display\b/i.test(txt) && txt.length < 20) return el;
+  }
+  return null;
+}
+
+function ensureShowAllButton(table) {
+  let btn = document.getElementById("cqt-show-all-btn");
+  if (btn && btn.isConnected) {
+    updateShowAllButtonLabel();
+    return btn;
+  }
+  // Stale / removed — rebuild fresh
+  btn = document.createElement("button");
+  btn.id = "cqt-show-all-btn";
+  btn.type = "button";
+  btn.style.cssText = [
+    "padding:4px 10px",
+    "margin-right:8px",
+    "border:1px solid rgba(0,0,0,0.15)",
+    "background:white",
+    "border-radius:4px",
+    "cursor:pointer",
+    "font-size:12px",
+    "font-weight:500",
+    "white-space:nowrap",
+    "line-height:1.4",
+    "vertical-align:middle",
+  ].join(";");
+  btn.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const t = getWatchlistTable();
+    if (t) await toggleShowAll(t);
+  });
+
+  // Preferred placement: immediately to the LEFT of Composer's "Display"
+  // dropdown in the top-right controls row.
+  const displayBtn = findDisplayDropdown();
+  if (displayBtn && displayBtn.parentNode) {
+    displayBtn.parentNode.insertBefore(btn, displayBtn);
+  } else {
+    // Fallback: floating toolbar above the table
+    let toolbar = document.getElementById("cqt-watchlist-toolbar");
+    if (!toolbar) {
+      toolbar = document.createElement("div");
+      toolbar.id = "cqt-watchlist-toolbar";
+      toolbar.style.cssText =
+        "display:flex;justify-content:flex-end;padding:6px 0;margin:4px 0;";
+      table.parentElement?.insertBefore(toolbar, table);
+    }
+    toolbar.appendChild(btn);
+  }
+  updateShowAllButtonLabel();
+  return btn;
+}
+
+function updateShowAllButtonLabel() {
+  const btn = document.getElementById("cqt-show-all-btn");
+  if (!btn) return;
+  btn.textContent = showAllActive ? "Paginate" : "Show all";
+  btn.title = showAllActive
+    ? "Restore Composer's paginated view (needed for Buy and Watch actions)"
+    : "Load all symphonies in one scrolling list (Buy/Watch buttons disabled while active; click a name to open its side panel)";
+  btn.style.background = showAllActive ? "#DBEAFE" : "white";
+  btn.style.borderColor = showAllActive ? "#60A5FA" : "rgba(0,0,0,0.15)";
+}
+
+function showBanner(table, text) {
+  let banner = document.getElementById("cqt-sort-banner");
+  if (!banner) {
+    banner = document.createElement("div");
+    banner.id = "cqt-sort-banner";
+    banner.style.cssText =
+      "padding:8px 16px;background:#EFF6FF;border:1px solid #BFDBFE;border-radius:6px;margin:8px 0;font-size:13px;color:#1E40AF;";
+    table.parentElement?.insertBefore(banner, table);
+  }
+  banner.textContent = text;
+  banner.style.display = "";
+}
+
+function hideBanner() {
+  const banner = document.getElementById("cqt-sort-banner");
+  if (banner) banner.style.display = "none";
+}
+
+// ---------------------------------------------------------------------------
+// Show-all activation / deactivation
+// ---------------------------------------------------------------------------
+
+function hidePaginationControls(table) {
+  stashedPagination = [];
+  const scope = table.parentElement?.parentElement || document.body;
+  const divs = scope.querySelectorAll("div");
+  for (const d of divs) {
+    const txt = (d.textContent || "").trim();
+    if (
+      /^\s*Prev\s+Next\s+\d/.test(txt) ||
+      /\d+\s+total\s*\|\s*Prev/.test(txt)
+    ) {
+      if (d.style.display !== "none") {
+        stashedPagination.push({ el: d, original: d.style.display });
+        d.style.display = "none";
+      }
+    }
+  }
+}
+
+function restorePaginationControls() {
+  for (const { el, original } of stashedPagination) {
+    el.style.display = original || "";
+  }
+  stashedPagination = [];
+}
+
+async function toggleShowAll(table) {
+  if (showAllActive) {
+    deactivateShowAll();
+    return;
+  }
+  await activateShowAll(table);
+}
+
+async function activateShowAll(table) {
+  showBanner(table, "Loading all symphonies…");
+
+  let watchlist;
+  try {
+    watchlist = await fetchWatchlist();
+  } catch (e) {
+    log("[watchlistSort] watchlist fetch failed:", e);
+    showBanner(table, `Could not load watchlist: ${e.message}`);
+    return;
+  }
+
+  const tickers = collectTickers(watchlist.symphonies);
+  let quotes;
+  try {
+    quotes = await fetchQuotes(tickers);
+  } catch (e) {
+    log("[watchlistSort] quotes fetch failed:", e);
+    showBanner(table, `Could not load quotes: ${e.message}`);
+    return;
+  }
+
+  for (const s of watchlist.symphonies) {
+    s._todaysChange = computeTodaysChange(s, quotes);
+  }
+  const matched = watchlist.symphonies.filter(
+    (s) => typeof s._todaysChange === "number"
+  ).length;
+  log(
+    `[watchlistSort] computed today's change for ${matched}/${watchlist.symphonies.length} symphonies (quote keys: ${Object.keys(quotes).length})`
+  );
+
+  sortedSymphonies = [...watchlist.symphonies];
+  if (currentSortKey) applyClientSort();
+
+  if (!renderCustomTbody(table)) {
+    showBanner(table, "Could not render rows — no template row available.");
+    return;
+  }
+  hidePaginationControls(table);
+  showAllActive = true;
+  updateShowAllButtonLabel();
+  updateActiveArrowOnNativeHeaders(table);
+
+  const sortLabel = currentSortKey ? ` sorted by ${currentSortKey}` : "";
+  showBanner(
+    table,
+    `Showing all ${sortedSymphonies.length} symphonies${sortLabel}. Click any column header to re-sort. Click a name to open its side panel. Click "Paginate" to restore Composer's default view (including Buy and Watch actions).`
+  );
+}
+
+function deactivateShowAll() {
+  isApplyingDomChange = true;
+  try {
+    if (customTbody && customTbody.parentNode) {
+      customTbody.parentNode.removeChild(customTbody);
+    }
+    if (originalTbody) {
+      originalTbody.style.display = "";
+    }
+  } finally {
+    isApplyingDomChange = false;
+  }
+  restorePaginationControls();
+  hideBanner();
+  customTbody = null;
+  originalTbody = null;
+  showAllActive = false;
+  currentSortKey = null;
+  updateShowAllButtonLabel();
+  const table = getWatchlistTable();
+  if (table) updateActiveArrowOnNativeHeaders(table);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering the full tbody
+// ---------------------------------------------------------------------------
+
+// Replace the TEXT content of a cell in place — preserves the td's classes
+// (padding, alignment, etc.) so row heights match Composer's native styling.
+function setCellTextPreserveStyle(cell, text, color) {
+  if (!cell) return;
+  cell.textContent = "";
+  if (color) {
+    const span = document.createElement("span");
+    span.textContent = text;
+    span.style.color = color;
+    cell.appendChild(span);
+  } else {
+    cell.appendChild(document.createTextNode(text));
+  }
+}
+
+function renderRow(symphony, colMap, templateRow) {
+  const tr = templateRow.cloneNode(true);
+  const cells = Array.from(tr.children);
+
+  // Name cell: clear the template content and rebuild minimally. The td's own
+  // classes (padding, alignment) are preserved because we only touch innerHTML,
+  // not the td attributes. No extra wrapping div with padding — that's what
+  // inflated row heights in the previous iteration.
+  if (colMap.name !== undefined && cells[colMap.name]) {
+    const cell = cells[colMap.name];
+    cell.innerHTML = "";
+
+    const newName = symphony.name || "(unnamed)";
+    const tickers = (symphony.tickers || [])
+      .slice(0, 3)
+      .map((t) =>
+        typeof t === "string" ? t.split("::")[1]?.split("//")[0] || t : t.symbol
+      )
+      .filter(Boolean);
+    const extra = (symphony.tickers || []).length - tickers.length;
+    const tradingText = `Trading: ${tickers.join(", ")}${extra > 0 ? `, +${extra}` : ""}`;
+
+    const nameLink = document.createElement("a");
+    // Use Composer's own factsheet URL so clicking opens the side panel
+    // rather than navigating to the full /symphony page. Intercept the
+    // click and push-state so Composer's router re-renders in place.
+    nameLink.href = `/watch?factsheet=${symphony.id}`;
+    nameLink.textContent = newName;
+    nameLink.style.cssText =
+      "font-weight:500;color:inherit;text-decoration:none;display:block;line-height:1.2;margin:0;";
+    nameLink.onmouseover = () => (nameLink.style.textDecoration = "underline");
+    nameLink.onmouseout = () => (nameLink.style.textDecoration = "none");
+    nameLink.addEventListener("click", (e) => {
+      // Let cmd/ctrl/middle-click open a new tab normally
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+      e.preventDefault();
+      const url = `/watch?factsheet=${symphony.id}`;
+      window.history.pushState({}, "", url);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    const trading = document.createElement("div");
+    trading.textContent = tradingText;
+    trading.style.cssText =
+      "font-size:10px;color:rgba(0,0,0,0.5);line-height:1.2;margin:0;";
+
+    cell.appendChild(nameLink);
+    cell.appendChild(trading);
+  }
+
+  const { text: tcText, color: tcColor } = fmtTodaysChange(symphony._todaysChange);
+  setCellTextPreserveStyle(cells[colMap.todayschange], tcText, tcColor);
+  setCellTextPreserveStyle(cells[colMap.watchedsince], fmtDate(symphony.watched_since));
+  setCellTextPreserveStyle(cells[colMap.outofsampledate], "—");
+  setCellTextPreserveStyle(
+    cells[colMap.annualizedreturn],
+    fmtPercent((symphony.annualized_rate_of_return ?? 0) * 100, 1)
+  );
+  setCellTextPreserveStyle(
+    cells[colMap.cumulativereturn],
+    fmtPercent((symphony.simple_return ?? 0) * 100, 1)
+  );
+  setCellTextPreserveStyle(cells[colMap.sharperatio], fmtRatio(symphony.sharpe_ratio, 2));
+  setCellTextPreserveStyle(cells[colMap.calmarratio], fmtRatio(symphony.calmar_ratio, 2));
+  setCellTextPreserveStyle(
+    cells[colMap.standarddeviation],
+    fmtPercent((symphony.standard_deviation ?? 0) * 100, 1)
+  );
+  setCellTextPreserveStyle(
+    cells[colMap.maxdrawdown],
+    fmtPercent((symphony.max_drawdown ?? 0) * 100, 1)
+  );
+  setCellTextPreserveStyle(
+    cells[colMap.trailing1mreturn],
+    fmtPercent((symphony.trailing_one_month_return ?? 0) * 100, 1)
+  );
+  setCellTextPreserveStyle(
+    cells[colMap.trailing3mreturn],
+    fmtPercent((symphony.trailing_three_month_return ?? 0) * 100, 1)
+  );
+
+  tr.dataset.cqtCustomRow = "true";
+  return tr;
+}
+
+function renderCustomTbody(table) {
+  const colMap = buildColumnIndexMap(table);
+  const existingTbody = table.querySelector("tbody:not([data-cqt-custom-tbody])");
+  if (!existingTbody) return false;
+  const templateRow = existingTbody.querySelector("tr");
+  if (!templateRow) return false;
+
+  const newTbody = document.createElement("tbody");
+  newTbody.dataset.cqtCustomTbody = "true";
+  for (const s of sortedSymphonies) {
+    try {
+      newTbody.appendChild(renderRow(s, colMap, templateRow));
+    } catch (e) {
+      log("[watchlistSort] render error for", s.id, e);
+    }
+  }
+
+  isApplyingDomChange = true;
+  try {
+    originalTbody = existingTbody;
+    originalTbody.style.display = "none";
+    originalTbody.parentNode.insertBefore(newTbody, originalTbody.nextSibling);
+    customTbody = newTbody;
+  } finally {
+    isApplyingDomChange = false;
+  }
+  return true;
+}
+
+function rerenderCustomTbody(table) {
+  if (!customTbody || !customTbody.parentNode) return;
+  const colMap = buildColumnIndexMap(table);
+  // Prefer the original tbody's first row as template (richest structure);
+  // fall back to our own row.
+  const templateRow =
+    originalTbody?.querySelector("tr") || customTbody.querySelector("tr");
+  if (!templateRow) return;
+
+  isApplyingDomChange = true;
+  try {
+    customTbody.innerHTML = "";
+    for (const s of sortedSymphonies) {
+      try {
+        customTbody.appendChild(renderRow(s, colMap, templateRow));
+      } catch (e) {
+        log("[watchlistSort] rerender error for", s.id, e);
+      }
+    }
+  } finally {
+    isApplyingDomChange = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+function applyClientSort() {
+  const getter = COLUMN_VALUE_GETTERS[currentSortKey];
+  if (!getter) return;
+  const dir = currentSortDir === "asc" ? 1 : -1;
+  sortedSymphonies.sort((a, b) => {
+    const va = getter(a);
+    const vb = getter(b);
+    if (va === null && vb === null) return 0;
+    if (va === null) return 1;
+    if (vb === null) return -1;
+    if (typeof va === "string" || typeof vb === "string") {
+      return dir * String(va).localeCompare(String(vb));
+    }
+    return dir * (va - vb);
+  });
+}
+
+function perPageSortTodaysChange(table) {
+  const tbody = table.querySelector("tbody:not([data-cqt-custom-tbody])");
+  if (!tbody) return;
+  const headers = Array.from(table.querySelectorAll("thead th"));
+  const idx = headers.findIndex((th) => TODAYS_CHANGE_RE.test(th.textContent || ""));
+  if (idx < 0) return;
+
+  const rows = Array.from(tbody.children).filter((r) => r.tagName === "TR");
+  const parse = (txt) => {
+    const t = (txt || "").trim();
+    if (!t || t === "-" || t === "—") return null;
+    const down = t.includes("↓");
+    const n = parseFloat(t.replace(/[↑↓%+\s,]/g, ""));
+    if (isNaN(n)) return null;
+    return down && n > 0 ? -n : n;
+  };
+  const dir = currentSortDir === "asc" ? 1 : -1;
+  rows.sort((a, b) => {
+    const va = parse(a.querySelectorAll(":scope > td")[idx]?.textContent);
+    const vb = parse(b.querySelectorAll(":scope > td")[idx]?.textContent);
+    if (va === null && vb === null) return 0;
+    if (va === null) return 1;
+    if (vb === null) return -1;
+    return dir * (va - vb);
+  });
+
+  isApplyingDomChange = true;
+  try {
+    rows.forEach((r) => tbody.appendChild(r));
+  } finally {
+    setTimeout(() => {
+      isApplyingDomChange = false;
+    }, 200);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header click wiring
+// ---------------------------------------------------------------------------
+
+function attachHeaderClickHandlers(table) {
+  if (table.dataset.cqtHeadersWired === "true") return;
+  const thead = table.querySelector("thead");
+  if (!thead) return;
+
+  thead.addEventListener(
+    "click",
+    async (e) => {
+      // Our Show-all button handles itself
+      if (e.target.closest("#cqt-show-all-btn")) return;
+
+      const th = e.target.closest("th");
+      if (!th) return;
+      const key = headerKey(th.textContent);
+      if (!COLUMN_VALUE_GETTERS[key]) return;
+
+      if (showAllActive) {
+        // Sort our rows client-side; don't let Composer re-paginate.
+        e.stopPropagation();
+        e.preventDefault();
+        if (currentSortKey === key) {
+          currentSortDir = currentSortDir === "desc" ? "asc" : "desc";
+        } else {
+          currentSortKey = key;
+          currentSortDir = "desc";
+        }
+        applyClientSort();
+        rerenderCustomTbody(table);
+        updateActiveArrowOnNativeHeaders(table);
+      } else if (key === "todayschange") {
+        // Not in show-all mode: clicking Today's Change activates Show-all
+        // (since Composer has no sort for this column anyway) and sorts by
+        // today's change desc. Subsequent clicks toggle direction.
+        e.stopPropagation();
+        e.preventDefault();
+        currentSortKey = "todayschange";
+        currentSortDir = "desc";
+        await activateShowAll(table);
+      }
+      // else: native columns fall through to Composer.
+    },
+    true // capture phase to beat Composer's bubble-phase listeners
+  );
+
+  table.dataset.cqtHeadersWired = "true";
+}
+
+// ---------------------------------------------------------------------------
+// Observer + lifecycle
+// ---------------------------------------------------------------------------
+
+function setupObserver(table) {
+  if (observer) return;
+  let scheduled = false;
+  observer = new MutationObserver(() => {
+    if (isApplyingDomChange || scheduled) return;
+    scheduled = true;
+    // Coalesce many React re-renders into one callback per frame
+    requestAnimationFrame(() => {
+      scheduled = false;
+      if (showAllActive) {
+        const currentOriginal = table.querySelector(
+          "tbody:not([data-cqt-custom-tbody])"
+        );
+        if (currentOriginal && currentOriginal.style.display !== "none") {
+          isApplyingDomChange = true;
+          try {
+            originalTbody = currentOriginal;
+            originalTbody.style.display = "none";
+            if (customTbody && !customTbody.isConnected) {
+              originalTbody.parentNode.insertBefore(
+                customTbody,
+                originalTbody.nextSibling
+              );
+            }
+          } finally {
+            isApplyingDomChange = false;
+          }
+        }
+      }
+    });
+  });
+  // Narrow scope: only watch direct children of the table (thead/tbody swaps).
+  // We don't need to observe the entire subtree — React makes many inner
+  // updates that aren't relevant, and observing all of them burns CPU.
+  observer.observe(table, { childList: true, subtree: false });
+}
+
+let tickCount = 0;
+let cachedTable = null;
+function tick() {
+  tickCount++;
+  // Reuse the cached table if it's still in the DOM — avoids scanning all
+  // tables + their thead textContent every second.
+  if (!cachedTable || !cachedTable.isConnected) {
+    cachedTable = getWatchlistTable();
+  }
+  const table = cachedTable;
+  if (!table) {
+    if (tickCount === 5 || tickCount === 30) {
+      log(
+        `[watchlistSort] tick ${tickCount}: no watchlist table yet (path=${location.pathname})`
+      );
+    }
+    return;
+  }
+  ensureShowAllButton(table);
+  ensureTodaysChangeArrow(table);
+  attachHeaderClickHandlers(table);
+  setupObserver(table);
+}
+
+export function initWatchlistSortModule() {
+  log("[watchlistSort] module init");
+  if (pollInterval) clearInterval(pollInterval);
+  pollInterval = setInterval(tick, 1000);
+  window.addEventListener("unload", () => {
+    if (pollInterval) clearInterval(pollInterval);
+    if (observer) observer.disconnect();
+  });
+}

--- a/src/utils/watchlistSort.js
+++ b/src/utils/watchlistSort.js
@@ -36,7 +36,7 @@ let originalTbody = null;
 let customTbody = null;
 let stashedPagination = [];
 let observer = null;
-let pollInterval = null;
+let mainObserver = null;
 let isApplyingDomChange = false;
 
 const WATCHLIST_CACHE_TTL = 5 * 60 * 1000;
@@ -750,36 +750,52 @@ function setupObserver(table) {
   observer.observe(table, { childList: true, subtree: false });
 }
 
-let tickCount = 0;
 let cachedTable = null;
-function tick() {
-  tickCount++;
-  // Reuse the cached table if it's still in the DOM — avoids scanning all
-  // tables + their thead textContent every second.
-  if (!cachedTable || !cachedTable.isConnected) {
-    cachedTable = getWatchlistTable();
+
+function isOnWatchlistPage() {
+  return window.location.pathname === "/watch";
+}
+
+function tryAttachToTable() {
+  if (!isOnWatchlistPage()) return false;
+  const table = getWatchlistTable();
+  if (!table) return false;
+  if (cachedTable && cachedTable !== table && observer) {
+    observer.disconnect();
+    observer = null;
   }
-  const table = cachedTable;
-  if (!table) {
-    if (tickCount === 5 || tickCount === 30) {
-      log(
-        `[watchlistSort] tick ${tickCount}: no watchlist table yet (path=${location.pathname})`
-      );
-    }
-    return;
-  }
+  cachedTable = table;
   ensureShowAllButton(table);
   ensureTodaysChangeArrow(table);
   attachHeaderClickHandlers(table);
   setupObserver(table);
+  return true;
+}
+
+function startMainObserver() {
+  if (mainObserver) return;
+  const root = document.querySelector("main") || document.body;
+  mainObserver = new MutationObserver(() => {
+    if (!isOnWatchlistPage()) return;
+    if (cachedTable && cachedTable.isConnected) return;
+    tryAttachToTable();
+  });
+  mainObserver.observe(root, { childList: true, subtree: true });
 }
 
 export function initWatchlistSortModule() {
   log("[watchlistSort] module init");
-  if (pollInterval) clearInterval(pollInterval);
-  pollInterval = setInterval(tick, 1000);
+
+  tryAttachToTable();
+  startMainObserver();
+
+  window.navigation?.addEventListener("navigate", (event) => {
+    if (!event.destination.url?.includes("/watch")) return;
+    setTimeout(tryAttachToTable, 100);
+  });
+
   window.addEventListener("unload", () => {
-    if (pollInterval) clearInterval(pollInterval);
+    if (mainObserver) mainObserver.disconnect();
     if (observer) observer.disconnect();
   });
 }

--- a/src/utils/watchlistSort.js
+++ b/src/utils/watchlistSort.js
@@ -658,42 +658,6 @@ function applyClientSort() {
   });
 }
 
-function perPageSortTodaysChange(table) {
-  const tbody = table.querySelector("tbody:not([data-cqt-custom-tbody])");
-  if (!tbody) return;
-  const headers = Array.from(table.querySelectorAll("thead th"));
-  const idx = headers.findIndex((th) => TODAYS_CHANGE_RE.test(th.textContent || ""));
-  if (idx < 0) return;
-
-  const rows = Array.from(tbody.children).filter((r) => r.tagName === "TR");
-  const parse = (txt) => {
-    const t = (txt || "").trim();
-    if (!t || t === "-" || t === "—") return null;
-    const down = t.includes("↓");
-    const n = parseFloat(t.replace(/[↑↓%+\s,]/g, ""));
-    if (isNaN(n)) return null;
-    return down && n > 0 ? -n : n;
-  };
-  const dir = currentSortDir === "asc" ? 1 : -1;
-  rows.sort((a, b) => {
-    const va = parse(a.querySelectorAll(":scope > td")[idx]?.textContent);
-    const vb = parse(b.querySelectorAll(":scope > td")[idx]?.textContent);
-    if (va === null && vb === null) return 0;
-    if (va === null) return 1;
-    if (vb === null) return -1;
-    return dir * (va - vb);
-  });
-
-  isApplyingDomChange = true;
-  try {
-    rows.forEach((r) => tbody.appendChild(r));
-  } finally {
-    setTimeout(() => {
-      isApplyingDomChange = false;
-    }, 200);
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Header click wiring
 // ---------------------------------------------------------------------------

--- a/src/utils/watchlistSort.js
+++ b/src/utils/watchlistSort.js
@@ -287,6 +287,24 @@ function findDisplayDropdown() {
   return null;
 }
 
+// Walk up from `el` looking for an ancestor that lays its children out
+// horizontally. Needed because Composer wraps the Display dropdown in a
+// vertical flex column, so inserting our button as an immediate sibling
+// stacks it above Display instead of beside it.
+function findHorizontalRowAncestor(el, maxDepth = 8) {
+  let cur = el?.parentElement;
+  for (let i = 0; i < maxDepth && cur; i++) {
+    const cs = getComputedStyle(cur);
+    const isFlex = cs.display === "flex" || cs.display === "inline-flex";
+    if (isFlex) {
+      const dir = cs.flexDirection || "row";
+      if (dir === "row" || dir === "row-reverse") return cur;
+    }
+    cur = cur.parentElement;
+  }
+  return null;
+}
+
 function ensureShowAllButton(table) {
   let btn = document.getElementById("cqt-show-all-btn");
   if (btn && btn.isConnected) {
@@ -318,9 +336,20 @@ function ensureShowAllButton(table) {
   });
 
   // Preferred placement: immediately to the LEFT of Composer's "Display"
-  // dropdown in the top-right controls row.
+  // dropdown in the top-right controls row. Walk up to the nearest horizontal
+  // flex ancestor first — Composer's new UI wraps Display in a column-axis
+  // container, so a direct insertBefore stacks our button above it.
   const displayBtn = findDisplayDropdown();
-  if (displayBtn && displayBtn.parentNode) {
+  const row = displayBtn ? findHorizontalRowAncestor(displayBtn) : null;
+  if (row) {
+    // Find the direct child of `row` that contains the Display button, then
+    // insert our button as its previous sibling — stays inline with Display.
+    let displayChild = displayBtn;
+    while (displayChild.parentNode && displayChild.parentNode !== row) {
+      displayChild = displayChild.parentNode;
+    }
+    row.insertBefore(btn, displayChild);
+  } else if (displayBtn && displayBtn.parentNode) {
     displayBtn.parentNode.insertBefore(btn, displayBtn);
   } else {
     // Fallback: floating toolbar above the table


### PR DESCRIPTION
## Summary

Adds two self-contained features, each scoped to a single page:

1. **Watchlist: "Show all" mode + client-side sorting across every symphony.** Composer paginates the watchlist server-side (20 rows per page), so the native sort arrows only sort the visible page, and "Today's Change" has no sort arrow at all. This PR adds a small **Show all** toggle button placed to the left of Composer's existing "Display" dropdown (top-right of the watchlist header), plus a sort arrow on the Today's Change column. Either control triggers the same flow: fetch `backtest-api/v1/watchlist` (all symphonies in one call) + `stagehand-api/v1/public/quotes` (batched in chunks of 100), compute today's change as the holdings-weighted percentage, render every symphony in one scrolling tbody, and hide Composer's pagination. While Show all is active, clicking **any** column header (Today's Change, Sharpe, Calmar, Annualized Return, Max Drawdown, etc.) re-sorts client-side using the raw API values — no server round-trips, no re-fetch. The button label flips to "Paginate" and clicking it restores Composer's default view.

2. **Drafts: bulk delete.** Adds a toolbar above the drafts table with `Select all "Copy of…" drafts` (skips rows whose name starts with `SAVE`), `Clear`, and `Delete selected (N)`, plus per-row checkboxes and a master header checkbox. Deletes run the existing trash → "Yes, delete" UI sequentially — no hidden API calls, no permission changes. Rows are identified by symphony ID (parsed from the row's link), not by name or DOM reference, so React's `<tr>` reuse during re-render can't misfire. Success is detected by the row's symphony ID disappearing from the DOM.

## Files

- `src/utils/watchlistSort.js` — new
- `src/utils/draftsBulkDelete.js` — new
- `src/init.js` — 2 new imports + 2 new init calls (no other changes)

No new permissions, no new host permissions, no hardcoded secrets. Both modules use the existing `getTokenAndAccount()` + `buildHeaders()` helpers for auth and only hit endpoints the app itself already calls (`stagehand-api.composer.trade`, `backtest-api.composer.trade`). The watchlist observer is narrowed to `childList: true, subtree: false` and its callback is coalesced through `requestAnimationFrame` to avoid CPU pressure during React re-renders.

## Test plan

Watchlist:
- [ ] Load `/watch`. A **Show all** button appears immediately to the left of Composer's "Display" dropdown; the Today's Change header gets a sort arrow + hover tooltip.
- [ ] Click **Show all** (or click the Today's Change header): banner "Loading all N symphonies…" appears, then updates to "Showing all N symphonies sorted by Today's Change…". Pagination controls hide. All rows render in one scrolling view; row height matches Composer's native spacing.
- [ ] Click any column header (Today's Change, Sharpe, Calmar, Max Drawdown, etc.): rows re-sort client-side; click again → direction flips; arrow indicator follows.
- [ ] Click **Paginate** (the button's label flips when Show all is active): custom tbody removed, Composer's original paginated view restored.

Drafts:
- [ ] Load `/draft`. Toolbar appears above the table; checkboxes appear in header and each row.
- [ ] Click `Select all "Copy of…" drafts`: every row whose name starts with "Copy of" gets checked (rows starting with "SAVE" are explicitly skipped); status line shows count.
- [ ] Uncheck a few to narrow the set. `Delete selected (N)` updates live.
- [ ] Click `Delete selected (N)` → browser confirms → status ticks through `Deleting 1 of N: <name>` etc. → finishes with `Deleted N drafts ✔`. Each deletion is ~500 ms; zero false failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
